### PR TITLE
fixes to work with maven 3.1 and download OG repos

### DIFF
--- a/corporate-parent/pom.xml
+++ b/corporate-parent/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>corporate-parent</artifactId>
   <packaging>pom</packaging>
   <name>Corporate-Parent</name>
-  <version>1.1.5</version>
+  <version>1.1.6</version>
   <description>OpenGamma maven corporate parent project</description>
   <organization>
     <name>OpenGamma</name>
@@ -472,7 +472,7 @@
     <build-helper-maven-plugin.version>1.8</build-helper-maven-plugin.version>
     <buildnumber-maven-plugin.version>1.2</buildnumber-maven-plugin.version>
     <exec-maven-plugin.version>1.2.1</exec-maven-plugin.version>
-    <opengamma-maven-plugin.version>1.3.1</opengamma-maven-plugin.version>
+    <opengamma-maven-plugin.version>1.3.2</opengamma-maven-plugin.version>
     <joda-beans-maven-plugin.version>0.7.3</joda-beans-maven-plugin.version>
     <fudge-proto-maven-plugin.version>0.3.9.7</fudge-proto-maven-plugin.version>
     <!-- Dependency versions -->

--- a/opengamma-maven-plugin/pom.xml
+++ b/opengamma-maven-plugin/pom.xml
@@ -13,7 +13,7 @@
   </parent>  
   <groupId>com.opengamma.tools</groupId>
   <artifactId>opengamma-maven-plugin</artifactId>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
   <packaging>maven-plugin</packaging>
   <name>OpenGamma Maven Plugin</name>
   <description>OpenGamma plugin for Apache Maven</description>
@@ -31,6 +31,24 @@
     <developerConnection>scm:git:https://github.com/OpenGamma/OG-Tools.git</developerConnection>
     <url>https://github.com/OpenGamma/OG-Tools</url>
   </scm>
+
+  <!-- ==================================================================== -->
+  <!-- OpenGamma public repositories -->
+  <!-- duplicated from corporate-pom to ensure this pom builds from scratch -->
+  <repositories>
+    <repository>
+      <id>og-public</id>
+      <name>OG Public</name>
+      <url>http://maven.opengamma.com/nexus/content/groups/public</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>og-public</id>
+      <name>OG Public</name>
+      <url>http://maven.opengamma.com/nexus/content/groups/public</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <!-- ==================================================================== -->
   <build>
@@ -98,7 +116,7 @@
     <dependency>
       <groupId>org.twdata.maven</groupId>
       <artifactId>mojo-executor</artifactId>
-      <version>2.0</version>
+      <version>2.1.0</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/scripts/pom.xml
+++ b/scripts/pom.xml
@@ -13,7 +13,7 @@
   </parent>  
   <groupId>com.opengamma.tools</groupId>
   <artifactId>scripts</artifactId>
-  <version>1.3.1</version>
+  <version>1.3.2</version>
   <packaging>jar</packaging>
   <name>Scripts</name>
   <description>Utilities for managing script files</description>
@@ -31,6 +31,24 @@
     <developerConnection>scm:git:https://github.com/OpenGamma/OG-Tools.git</developerConnection>
     <url>https://github.com/OpenGamma/OG-Tools</url>
   </scm>
+
+  <!-- ==================================================================== -->
+  <!-- OpenGamma public repositories -->
+  <!-- duplicated from corporate-pom to ensure this pom builds from scratch -->
+  <repositories>
+    <repository>
+      <id>og-public</id>
+      <name>OG Public</name>
+      <url>http://maven.opengamma.com/nexus/content/groups/public</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>og-public</id>
+      <name>OG Public</name>
+      <url>http://maven.opengamma.com/nexus/content/groups/public</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <!-- ==================================================================== -->
   <build>


### PR DESCRIPTION
These changes upgrades the pom files to compile against
mojo-executor 2.1.0 which is required for maven 3.1.
They also add OG public repositories into the repository
list making it easier for external users to build.
