### PR TITLE
TASK: Checkstyle updates

### DIFF
--- a/build-config/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-config/src/main/resources/checkstyle/checkstyle.xml
@@ -84,7 +84,7 @@
       <property name="logLoadErrors" value="true"/>
       <property name="suppressLoadErrors" value="true"/>
     </module>
-<!--    The below *should* work but is currently broken: https://github.com/checkstyle/checkstyle/issues/6192-->
+<!--    The below *should* work but is currently broken: https://github.com/checkstyle/checkstyle/issues/6192 -->
 <!--    <module name="JavadocParagraph">-->
 <!--      &lt;!&ndash; This rule ensures a new line before parameters. &ndash;&gt;-->
 <!--      &lt;!&ndash; And this means <p> elements can appear on a line of their own. &ndash;&gt;-->
@@ -126,7 +126,7 @@
     <module name="NoWhitespaceAfter"/>
     <module name="NoWhitespaceBefore">
       <property name="allowLineBreaks" value="true"/>
-      <property name="tokens" value="SEMI,DOT,POST_DEC,POST_INC"/>
+      <property name="tokens" value="ELLIPSIS,SEMI,DOT,POST_DEC,POST_INC"/>
     </module>
     <module name="OneTopLevelClass"/>
     <module name="OperatorWrap">
@@ -218,6 +218,11 @@
     <property name="fileExtensions" value="java"/>
   </module-->
   <module name="RegexpSingleline">
+    <property name="format" value="ListUtils.union"/>
+    <property name="message" value="Prefer Guavate.concatToList over ListUtils.union"/>
+    <property name="fileExtensions" value="java"/>
+  </module>
+  <module name="RegexpSingleline">
     <property name="format" value="import org.testng.collections."/>
     <property name="message" value="Invalid import, maybe you want com.google.common.collect"/>
     <property name="fileExtensions" value="java"/>
@@ -225,6 +230,7 @@
   <module name="RegexpSingleline">
     <property name="format" value="import org.testng.internal."/>
     <property name="message" value="Invalid import, internal testng classes not allowed"/>
+    <property name="fileExtensions" value="java"/>
   </module>
   <module name="RegexpSingleline">
     <property name="format" value="import com.beust.jcommander.internal."/>
@@ -234,6 +240,11 @@
   <module name="RegexpSingleline">
     <property name="format" value="UnsupportedEncodingException "/>
     <property name="message" value="Use constants on Guava Charsets class instead"/>
+    <property name="fileExtensions" value="java"/>
+  </module>
+  <module name="RegexpMultiline">
+    <property name="format" value="^[\r\n]*[^(\n\r]+\)[ ]*\{[ ]*(\n|\r\n)[ ]*[\S]+?"/>
+    <property name="message" value="When split across multiple lines, method parameters must be followed by a new line"/>
     <property name="fileExtensions" value="java"/>
   </module>
   <module name="SuppressWithPlainTextCommentFilter">

--- a/build-config/src/main/resources/checkstyle/checkstyle.xml
+++ b/build-config/src/main/resources/checkstyle/checkstyle.xml
@@ -185,6 +185,28 @@
       <property name="checkCPP" value="true"/>
       <property name="checkC" value="false"/>
     </module>
+    <module name="Regexp">
+      <property name="format" value="^[\r\n]*[^(\n\r]+\)[ ]*\{[ ]*(\n|\r\n)[ ]*[\S]+?"/>
+      <property name="message" value="When split across multiple lines, method parameters must be followed by a new line"/>
+      <property name="illegalPattern" value="true"/>
+    </module>
+    <module name="Regexp">
+      <!-- Matching closing argument e.g. `String foo, String bar) {` -->
+      <!-- Note: Does not match multiple arguments on their own line e.g. `String foo, String bar,` -->
+      <property name="format" value="^[^(\r\n]+[,](?![^,]*>)[^(\n\r]+\)[ ]*\{[ ]*$"/>
+      <property name="message" value="When split across multiple lines, each parameter must be placed on its own line"/>
+      <property name="illegalPattern" value="true"/>
+    </module>
+    <module name="Regexp">
+      <property name="format" value="^[ ]*\);[ ]*$"/>
+      <property name="message" value="Closing parenthesis should be on the same line as the last argument"/>
+      <property name="illegalPattern" value="true"/>
+    </module>
+    <module name="Regexp">
+      <property name="format" value="^[ ]*\)[ ]*\{[ ]*$"/>
+      <property name="message" value="Closing parenthesis should be on the same line as the last parameter"/>
+      <property name="illegalPattern" value="true"/>
+    </module>
   </module>
 
   <!-- Header inlined due to m2e -->
@@ -197,18 +219,6 @@
     <!-- (Not currently implemented explicitly in Checkstyle: https://github.com/checkstyle/checkstyle/issues/2506) -->
     <property name="format" value="^\s*\*\s*@author"/>
     <property name="message" value="Javadoc has illegal ''author'' tag."/>
-    <property name="fileExtensions" value="java"/>
-  </module>
-  <module name="RegexpSingleline">
-    <!-- (?!\h*\/\/|\h*\/\*\*|\h*\*\/|\h*\*) ignores lines beginning with comments (javadoc or plain) -->
-    <property name="format" value="^(?!\h*\/\/|\h*\/\*\*|\h*\*\/|\h*\*).*\([a-zA-Z\h,]+$"/>
-    <property name="message" value="When split across multiple lines, each argument must be placed on its own line"/>
-    <property name="fileExtensions" value="java"/>
-  </module>
-  <module name="RegexpSingleline">
-    <!-- (?!\h*\/\/|\h*\/\*\*|\h*\*\/|\h*\*) ignores lines beginning with comments (javadoc or plain) -->
-    <property name="format" value="^(?!\h*\/\/|\h*\/\*\*|\h*\*\/|\h*\*)[\h]*\);[\h]*$"/>
-    <property name="message" value="Closing parenthesis should be on the same line as the last argument"/>
     <property name="fileExtensions" value="java"/>
   </module>
   <!-- Tried this, but blast radius too high -->
@@ -240,11 +250,6 @@
   <module name="RegexpSingleline">
     <property name="format" value="UnsupportedEncodingException "/>
     <property name="message" value="Use constants on Guava Charsets class instead"/>
-    <property name="fileExtensions" value="java"/>
-  </module>
-  <module name="RegexpMultiline">
-    <property name="format" value="^[\r\n]*[^(\n\r]+\)[ ]*\{[ ]*(\n|\r\n)[ ]*[\S]+?"/>
-    <property name="message" value="When split across multiple lines, method parameters must be followed by a new line"/>
     <property name="fileExtensions" value="java"/>
   </module>
   <module name="SuppressWithPlainTextCommentFilter">


### PR DESCRIPTION
- Enforce ellipsis placement for varargs
- Enforce new line following multi-line method parameters
- Ban use of ListUtils.union(...)
- Convert single-line regex checks into regexp ones (so that they don't match against joda-beans-generated code)

Observation: Despite being run under Java 8+, the \h and \v character classes do not seem to work with Checkstyle's regular expression matchers, so I've replaced them with more simple whitespace checks that achieve the same thing.