### PR TITLE
Upgrade maven-enforcer-plugin

### DIFF
--- a/corporate-parent/pom.xml
+++ b/corporate-parent/pom.xml
@@ -731,7 +731,7 @@
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <!-- maven-dependency-plugin v3.1.2 is broken -->
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
-    <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
+    <maven-enforcer-plugin.version>3.0.0</maven-enforcer-plugin.version>
     <maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     <maven-help-plugin.version>3.2.0</maven-help-plugin.version>
@@ -757,7 +757,7 @@
     <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
     <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
     <exec-maven-plugin.version>3.0.0</exec-maven-plugin.version>
-    <extra-enforcer-rules.version>1.2</extra-enforcer-rules.version>
+    <extra-enforcer-rules.version>1.4</extra-enforcer-rules.version>
     <forbiddenapis-maven-plugin.version>3.1</forbiddenapis-maven-plugin.version>
     <github-release-plugin.version>1.3.0</github-release-plugin.version><!-- 1.2.1-OG -->
     <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>


### PR DESCRIPTION
Am trying to excluce `commons-logging` from a 3rd-party library (and put the corresponding SLF4J dependency on the classpath instead) but the enforcer plugin check banning duplicate classes fails after doing so.

Noting that 2 years have passed between the `3.0.0-M3` version we currently use and the newer `3.0.0` version I tried upgrading and that seems to have resolved the issue (though I've not been able to find a ticket/issue anywhere online referencing a fix).

The `extra-enforcer-rules` dependency needs bumping to work with the newer version of the plugin (for which I could find a [reference](https://github.com/mojohaus/extra-enforcer-rules/issues/132)).