### PR TITLE
PROD-39984: Bump joda-beans to version 2.11.1

### DIFF
--- a/corporate-parent/pom.xml
+++ b/corporate-parent/pom.xml
@@ -808,7 +808,7 @@
 
     <!-- Versions -->
     <jakarta.xml.bind-api.version>2.3.2</jakarta.xml.bind-api.version>
-    <joda-beans.version>2.11.0</joda-beans.version>
+    <joda-beans.version>2.11.1</joda-beans.version>
     <joda-convert.version>2.2.3</joda-convert.version>
 
     <!-- Properties for maven-compiler-plugin -->


### PR DESCRIPTION
The new version supports deserialisation of numeric values greater than the capacity of an int.